### PR TITLE
Auto-detect packets, no need for updating protos

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 /target
 /.direnv
+Packet.lib
+wpcap.lib

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -139,23 +139,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
 
 [[package]]
-name = "artifactarium"
-version = "1.0.0"
-source = "git+https://github.com/juliuskreutz/artifactarium#f8b01982fe5828cdc4036d5a0bb01e35a406a03c"
-dependencies = [
- "base64 0.22.1",
- "etherparse",
- "kcp",
- "protobuf",
- "protobuf-codegen",
- "rand_mt",
- "rsa",
- "serde",
- "serde_json",
- "tracing",
-]
-
-[[package]]
 name = "as-raw-xcb-connection"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -342,6 +325,39 @@ name = "atomic-waker"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
+
+[[package]]
+name = "auto-artifactarium"
+version = "1.0.0"
+source = "git+https://github.com/hashblen/auto-artifactarium#481e64bfd7e8654f78cc283b89070e5da96530ee"
+dependencies = [
+ "base64 0.22.1",
+ "etherparse",
+ "kcp",
+ "protobuf",
+ "protobuf-codegen",
+ "rand_mt",
+ "rsa",
+ "serde",
+ "serde_json",
+ "tracing",
+]
+
+[[package]]
+name = "auto-reliquary"
+version = "1.0.0"
+source = "git+https://github.com/hashblen/auto-reliquary#165d9a64285f8725a27343018f15062623444873"
+dependencies = [
+ "base64 0.22.1",
+ "etherparse",
+ "kcp",
+ "protobuf",
+ "protobuf-codegen",
+ "rand_mt",
+ "serde",
+ "serde_json",
+ "tracing",
+]
 
 [[package]]
 name = "autocfg"
@@ -2805,22 +2821,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
 
 [[package]]
-name = "reliquary"
-version = "5.0.0"
-source = "git+https://github.com/juliuskreutz/reliquary#c694a79d1ba9fd681bdb77ff38569ba4e8809698"
-dependencies = [
- "base64 0.22.1",
- "etherparse",
- "kcp",
- "protobuf",
- "protobuf-codegen",
- "rand_mt",
- "serde",
- "serde_json",
- "tracing",
-]
-
-[[package]]
 name = "reqwest"
 version = "0.12.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3359,11 +3359,12 @@ checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
 
 [[package]]
 name = "stardb-exporter"
-version = "2.3.2"
+version = "2.4.0"
 dependencies = [
  "anyhow",
  "arboard",
- "artifactarium",
+ "auto-artifactarium",
+ "auto-reliquary",
  "base64 0.22.1",
  "eframe",
  "egui",
@@ -3371,7 +3372,6 @@ dependencies = [
  "egui_extras",
  "pcap",
  "regex",
- "reliquary",
  "rfd",
  "self_update",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,12 +1,12 @@
 [package]
 name = "stardb-exporter"
-version = "2.3.2"
+version = "2.4.0"
 edition = "2021"
 
 [dependencies]
 anyhow = "1.0.93"
 arboard = "3.4.1"
-artifactarium = { git = "https://github.com/juliuskreutz/artifactarium" }
+auto-artifactarium = { git = "https://github.com/hashblen/auto-artifactarium" }
 base64 = "0.22.1"
 eframe = { version = "0.29.1", default-features = false, features = [
     "default_fonts",
@@ -18,7 +18,7 @@ egui-notify = "0.17.0"
 egui_extras = { version = "0.29.1", features = ["all_loaders"] }
 pcap = "2.2.0"
 regex = "1.11.1"
-reliquary = { git = "https://github.com/juliuskreutz/reliquary" }
+auto-reliquary = { git = "https://github.com/hashblen/auto-reliquary" }
 rfd = "0.15.0"
 self_update = { version = "0.41.0", features = [
     "archive-zip",

--- a/src/games/gi.rs
+++ b/src/games/gi.rs
@@ -6,7 +6,7 @@ use std::{
     sync::mpsc,
 };
 
-use artifactarium::{command_id, gen::protos::AchievementAllDataNotify, GamePacket, GameSniffer};
+use auto_artifactarium::{GamePacket, GameSniffer, matches_achievement_packet};
 use base64::prelude::*;
 
 use regex::Regex;
@@ -26,18 +26,16 @@ pub fn sniff(
         };
 
         for command in commands {
-            if command.command_id == command_id::ACHIEVEMENT_ALL_DATA_NOTIFY {
+            if let Some(read_achievements) = matches_achievement_packet(&command) {
                 if !achievements.is_empty() {
                     continue;
                 }
 
-                if let Ok(quest_data) = command.parse_proto::<AchievementAllDataNotify>() {
-                    for quest in quest_data.achievement_list {
-                        if achievement_ids.contains(&quest.id)
-                            && (quest.status.value() == 2 || quest.status.value() == 3)
-                        {
-                            achievements.push(quest.id);
-                        }
+                for achievement in read_achievements {
+                    if achievement_ids.contains(&achievement.id)
+                        && (achievement.status == 2 || achievement.status == 3)
+                    {
+                        achievements.push(achievement.id);
                     }
                 }
             }

--- a/src/games/hsr.rs
+++ b/src/games/hsr.rs
@@ -7,7 +7,7 @@ use std::{
 };
 
 use base64::prelude::*;
-use reliquary::{command_id, gen::protos::GetQuestDataScRsp, GamePacket, GameSniffer};
+use auto_reliquary::{GamePacket, GameSniffer, matches_achievement_packet};
 
 pub fn sniff(
     achievement_ids: &[u32],
@@ -25,18 +25,16 @@ pub fn sniff(
         };
 
         for command in commands {
-            if command.command_id == command_id::GET_QUEST_DATA_SC_RSP {
+            if let Some(read_achievements) = matches_achievement_packet(&command) {
                 if !achievements.is_empty() {
                     continue;
                 }
 
-                if let Ok(quest_data) = command.parse_proto::<GetQuestDataScRsp>() {
-                    for quest in quest_data.quest_list {
-                        if achievement_ids.contains(&quest.id)
-                            && (quest.status.value() == 2 || quest.status.value() == 3)
-                        {
-                            achievements.push(quest.id);
-                        }
+                for achievement in read_achievements {
+                    if achievement_ids.contains(&achievement.id)
+                        && (achievement.status == 2 || achievement.status == 3)
+                    {
+                        achievements.push(achievement.id);
                     }
                 }
             }


### PR DESCRIPTION
This PR uses my repos auto-artifactarium and auto-reliquary, which detect the packets on their own without proto definitions, meaning the libraries don't have to be updated at each update :)
Keys still have to be pushed here for HSR since they change each update, and less frequently for gi.
(Sadly there is no way to automate the key getting process without making a proxy and installing a certificate, so will still need to be done manually)