### PR TITLE
Add reminder about opening the signal history in-game before trying to export

### DIFF
--- a/src/ui/pull_menu.rs
+++ b/src/ui/pull_menu.rs
@@ -39,6 +39,13 @@ pub fn show(ui: &mut egui::Ui, app: &App) {
         }
     }
 
+    let reminder = match app.game {
+        games::Game::Hsr => "Reminder: open the Warp menu in-game and press the 'Details' and 'History' buttons before exporting your history.",
+        games::Game::Gi => "Reminder: open the Wish menu in-game and press the 'Details' and 'History' buttons before exporting your history.",
+        games::Game::Zzz => "Reminder: open the Signal menu in-game and press the 'Details' and 'History' buttons before exporting your history.",
+    };
+    ui.label(reminder);
+
     if ui.button("Automatic").clicked() {
         match app.game.game_path() {
             Ok(path) => app.message_tx.send(Message::Path(path)).unwrap(),


### PR DESCRIPTION
I thought the manual signal search was broken, but it turns out I had just forgotten to access the search recently in-game, so the URL wasn't in the output. 

This PR adds a reminder.